### PR TITLE
Store realm in the OAuth grant

### DIFF
--- a/src/letswifi/letswifiapp.php
+++ b/src/letswifi/letswifiapp.php
@@ -72,7 +72,9 @@ class LetsWifiApp
 		$userId = $auth->requireAuth();
 		$userRealmPrefix = $auth->getUserRealmPrefix();
 
-		return new User( $userId, null, $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $userRealmPrefix );
+		$realm = $userRealmPrefix ?? $this->getRealm()->getName();
+
+		return new User( $userId, $realm, null, $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	public function getUserFromGrant( Grant $grant ): User
@@ -81,13 +83,13 @@ class LetsWifiApp
 		if ( null === $sub ) {
 			throw new DomainException( 'No user subject available' );
 		}
-		$sub_values = \explode( ',', $sub );
 
-		if ( 2 === \count( $sub_values ) ) {
-			return new User( $sub_values[0], $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'], $sub_values[1] );
+		$realm = $grant->realm;
+		if ( empty( $realm ) ) {
+			throw new DomainException( 'User has no realm' );
 		}
 
-		return new User( $sub, $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
+		return new User( $sub, $realm, $grant->getClientId(), $this->getIP(), $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	public function getIP(): string

--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -178,13 +178,7 @@ class Realm
 	protected function generateClientCertificate( User $user, DateTimeInterface $expiry ): PKCS12
 	{
 		$userKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_RSA ) );
-		// empty, because both null === and empty string values should stay out of the realm
-		$userAltRealm = $user->getUserAltRealm();
-		if ( empty( $userAltRealm ) ) {
-			$commonName = static::createCommonName( '@' . \rawurlencode( $this->getName() ) );
-		} else {
-			$commonName = static::createCommonName( '@' . \rawurlencode( \implode( '.', [$userAltRealm, $this->getName()] ) ) );
-		}
+		$commonName = static::createCommonName( '@' . \rawurlencode( $this->getName() ) );
 		$dn = new DN( ['CN' => $commonName] );
 		$csr = CSR::generate( $dn, $userKey );
 		$caCert = $this->getSigningCACertificate();

--- a/src/letswifi/realm/user.php
+++ b/src/letswifi/realm/user.php
@@ -24,16 +24,16 @@ class User
 	/** @var ?string */
 	private $userAgent;
 
-	/** @var ?string */
-	private $userAltRealm;
+	/** @var string */
+	private $realm;
 
-	public function __construct( string $userId, ?string $clientId = null, ?string $ip = null, ?string $userAgent = null, ?string $userAltRealm = null )
+	public function __construct( string $userId, string $realm, ?string $clientId = null, ?string $ip = null, ?string $userAgent = null )
 	{
 		$this->userId = $userId;
+		$this->realm = $realm;
 		$this->clientId = $clientId;
 		$this->ip = $ip;
 		$this->userAgent = $userAgent;
-		$this->userAltRealm = $userAltRealm;
 	}
 
 	public function getUserId(): string
@@ -56,8 +56,8 @@ class User
 		return $this->userAgent;
 	}
 
-	public function getUserAltRealm(): ?string
+	public function getRealm(): ?string
 	{
-		return $this->userAltRealm;
+		return $this->realm;
 	}
 }

--- a/www/oauth/authorize/index.php
+++ b/www/oauth/authorize/index.php
@@ -28,11 +28,13 @@ try {
 	$user = $app->getUserFromBrowserSession( $realm );
 
 	if ( 'POST' === $_SERVER['REQUEST_METHOD'] ) {
-		if ( null === $browserAuth->getUserRealmPrefix() ) {
-			$oauth->handleAuthorizePostRequest( $user->getUserId(), POST_VALUE === $_POST[POST_FIELD] );
-		} else {
-			$oauth->handleAuthorizePostRequest( $user->getUserId() . ',' . $browserAuth->getUserRealmPrefix(), POST_VALUE === $_POST[POST_FIELD] );
-		}
+		$userRealmPrefix = $browserAuth->getUserRealmPrefix();
+		$oauth->handleAuthorizePostRequest( new fyrkat\oauth\token\Grant(
+			[
+				'sub' => $user->getUserId(),
+				'realm' => $userRealmPrefix ?? $realm->getName(),
+			]
+		), POST_VALUE === $_POST[POST_FIELD] );
 
 		// handler should never return, this code should be unreachable
 		\header( 'Content-Type: text/plain' );


### PR DESCRIPTION
This prevents a scenario where the user can switch out the realm between requests.  It also simplifies the code for alternative (sub)realms.

This may be a better solution than using `,` in the username, but I haven't been able to test this yet.