### PR TITLE
Fix typo in manual profile url

### DIFF
--- a/www/app/index.php
+++ b/www/app/index.php
@@ -34,6 +34,6 @@ $app->render( [
 		'url' => "${basePath}/profiles/mac/",
 	],
 	'manual' => [
-		'url' => "${basePath}profiles/new/",
+		'url' => "${basePath}/profiles/new/",
 	],
 ], 'app', $basePath );


### PR DESCRIPTION
This fixes a type that made the manual link not work