### PR TITLE
Update for SimpleSAMLphp 2.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 REALM := example.com
-SIMPLESAMLPHP_VERSION := 2.1.1
+SIMPLESAMLPHP_VERSION := 2.1.3
 
 camera-ready-dev: camera-ready dev
 .PHONY: camera-ready-dev

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 
 REALM := example.com
+SIMPLESAMLPHP_VERSION := 2.1.1
 
 camera-ready-dev: camera-ready dev
 .PHONY: camera-ready-dev
@@ -49,9 +50,9 @@ var/letswifi-dev.sqlite: var
 
 simplesamlphp:
 	cp -n etc/letswifi.conf.simplesaml.php etc/letswifi.conf.php
-	curl -sSL https://github.com/simplesamlphp/simplesamlphp/releases/download/v1.18.8/simplesamlphp-1.18.8.tar.gz | tar xz
-	ln -s ../simplesamlphp/www/ www/simplesaml || true
-	ln -s simplesamlphp-1.18.8/ simplesamlphp || true
+	curl -sSL https://github.com/simplesamlphp/simplesamlphp/releases/download/v$(SIMPLESAMLPHP_VERSION)/simplesamlphp-$(SIMPLESAMLPHP_VERSION).tar.gz | tar xz
+	ln -sf simplesamlphp-$(SIMPLESAMLPHP_VERSION)/ simplesamlphp || true
+	ln -sf ../simplesamlphp/public/ www/simplesaml || true
 
 
 # Code formatters, static code sniffers etc.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Upload this whole project to a webserver, and make `www/` accessible as the top 
 
 This quick'n'dirty guide assumes you'll be using SimpleSAMLphp (the only authentication method supported for production)
 
-	make simplesamlphp
+	make SIMPLESAMLPHP_VERSION=2.1.1 simplesamlphp
 
 Initialize the SQLite database (MySQL is also supported, this should be straightforward from the config file)
 

--- a/etc/letswifi.conf.simplesaml.php
+++ b/etc/letswifi.conf.simplesaml.php
@@ -5,7 +5,7 @@
 		//'jornane', // A NameID or userIdAttribute
 	],
 	'auth.params' => [
-			'autoloadInclude' => dirname( __DIR__ ) . '/simplesamlphp/lib/_autoload.php',
+			'autoloadInclude' => dirname( __DIR__ ) . '/simplesamlphp/src/_autoload.php',
 			'authSource' => 'default-sp',
 		],
 	'realm.selector' => 'getparam', // one of null, getparam or httphost


### PR DESCRIPTION
The current Makefile installs SimpleSAMLphp 1.18.x which is both end-of-life and has known security vulnerabilities. As 1.19.x is also imminently EOL, this makes the changes necessary to update to SimpleSAMLphp 2.1.x (current stable).

It also introduces a `SIMPLESAMLPHP_VERSION` environment variable to make it easier to deploy with a more up-to-date version in future.