### PR TITLE
install-letswifi-portal.sh: Enable `setenvif` Apache module to ensure access to `Authorization` header

### DIFF
--- a/contrib/install/install-letswifi-portal.sh
+++ b/contrib/install/install-letswifi-portal.sh
@@ -122,7 +122,7 @@ test -f "/var/lib/acme/certs/$fqdn/$fqdn.key" || test -f "/var/lib/acme/certs/$f
 cp "/var/lib/acme/certs/$fqdn/$fqdn.cer" "/var/lib/acme/certs/$fqdn/fullchain.cer"
 a2dissite 000-default default-ssl
 a2ensite letswifi-portal
-a2enmod ssl proxy_fcgi
+a2enmod ssl proxy_fcgi setenvif
 service apache2 restart
 >/var/www/html/index.html
 


### PR DESCRIPTION
The Let's WiFi app implicitly relies on access to the HTTP `Authorization` header, specifically through its `fyrkat/oauth-server` dependency, which accesses it via a code path that calls [`fyrkat\oauth\Request->getBearerToken`](https://git.sr.ht/~jornane/php-oauth-server/tree/main/item/src/fyrkat/oauth/request.php#L93).

By default, Apache restricts script access to this header. In later versions of Apache 2.4, access can be enabled using the [CGIPassAuth](https://httpd.apache.org/docs/2.4/mod/core.html#cgipassauth) directive, which is also respected by `mod_proxy_fcgi`. However, another common approach is to use `mod_setenvif` to copy the header value to an environment variable.

The Debian `php-fpm` binary package [includes a configuration directive for this purpose](https://salsa.debian.org/php-team/php/-/blob/debian/main/8.2/debian/php-fpm.conf#L6) but does not enable `mod_setenvif` by default. Instead, it [suggests that the module be explicitly enabled](https://salsa.debian.org/php-team/php/-/blob/debian/main/8.2/debian/php-fpm.postinst.extra#L8).

This install script assumes an environment where such a configuration is required, and should therefore run `a2enmod setenvif`.