### PR TITLE
Problem: The listUserCertificates function ignores revoked certificates

### DIFF
--- a/src/letswifi/realm/databasestorage.php
+++ b/src/letswifi/realm/databasestorage.php
@@ -128,6 +128,7 @@ class DatabaseStorage
 			switch ( $key ) {
 				case 'issued': $query .= '`issued` < :issued'; break;
 				case 'expires': $query .= '(`expires` > :expires OR `expires` IS NULL)'; break;
+				case 'revoked': $query .= '(`revoked` > :revoked OR `revoked` IS NULL)'; break;
 				default: $query .= \is_array( $value )
 					? "`${key}` IN (:" . $key . \implode( ",:${key}", \array_keys( $value ) ) . ')'
 					: "`${key}` = :${key}"

--- a/src/letswifi/realm/realmmanager.php
+++ b/src/letswifi/realm/realmmanager.php
@@ -48,6 +48,7 @@ class RealmManager extends DatabaseStorage
 			'realm' => $realm,
 			'requester' => $user,
 			'expires' => \gmdate( static::DATE_FORMAT ),
+			'revoked' => \gmdate( static::DATE_FORMAT ),
 		] );
 	}
 

--- a/src/letswifi/realm/realmmanager.php
+++ b/src/letswifi/realm/realmmanager.php
@@ -42,14 +42,18 @@ class RealmManager extends DatabaseStorage
 		return new Realm( $this, $realm );
 	}
 
-	public function listUserCertificates( string $realm, string $user ): array
+	public function listUserCertificates( string $realm, string $user, bool $hideRevoked = false ): array
 	{
-		return $this->getEntriesFromTableWhere( 'realm_signing_log', [
+		$query = [
 			'realm' => $realm,
 			'requester' => $user,
 			'expires' => \gmdate( static::DATE_FORMAT ),
-			'revoked' => \gmdate( static::DATE_FORMAT ),
-		] );
+		];
+		if ( $hideRevoked ) {
+			$query['revoked'] = \gmdate( static::DATE_FORMAT );
+		}
+
+		return $this->getEntriesFromTableWhere( 'realm_signing_log', $query );
 	}
 
 	public function getCertificate( string $realm, string $subject ): ?array

--- a/www/admin/user/get/index.php
+++ b/www/admin/user/get/index.php
@@ -28,8 +28,10 @@ $app->requireAdmin( 'admin-user-get' );
 $realmManager = $app->getRealmManager();
 $realm = $app->getRealm();
 
+$hideRevoked = \array_key_exists( 'revoked', $_GET ) && '0' === $_GET['revoked'];
+
 if ( $user ) {
-	$certificates = $realmManager->listUserCertificates( $realm->getName(), $user );
+	$certificates = $realmManager->listUserCertificates( $realm->getName(), $user, $hideRevoked );
 	$queryVars = ['user' => $user];
 } elseif ( $subject ) {
 	$certificate = $realmManager->getCertificate( $realm->getName(), $subject );


### PR DESCRIPTION
Problem: In the src/letswifi/realm/realmmanager.php file, listUserCertificates function ignores revoked certificates and counts them as valid.

The included patch fixes it: [letswifi-portal-lucnt_2024-11-12_patch.txt](https://github.com/user-attachments/files/17716732/letswifi-portal-lucnt_2024-11-12_patch.txt)

Thank you very much for any help.

Regards: István