### PR TITLE
Update certificatecredentiallog.php

### DIFF
--- a/src/letswifi/credential/certificatecredentiallog.php
+++ b/src/letswifi/credential/certificatecredentiallog.php
@@ -47,7 +47,7 @@ class CertificateCredentialLog extends CredentialLog
 		$clientQueryPart = null === $client ? '' : 'AND client = :client';
 		$realmQueryPart = null === $realm ? '' : 'AND realm = :realm';
 		$statement = $this->getPDO()->prepare( <<<SQL
-			SELECT realm, ca_sub, requester, ident, "grant", usage, sub, issued, expires, revoked, csr, client, user_agent, ip, x509
+			SELECT realm, ca_sub, requester, ident, "grant", "usage", sub, issued, expires, revoked, csr, client, user_agent, ip, x509
 			FROM realm_signing_log
 			WHERE requester = :requester
 				AND expires > :now


### PR DESCRIPTION
Fixed error at /me: 
PDOException: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'usage, sub, issued, expires, revoked, csr, client, user_agent, ip, x509 FROM ...' at line 1