### PR TITLE
Fix AnonymousIdentity not set under Linux and Android

### DIFF
--- a/src/letswifi/credential/certificatecredential.php
+++ b/src/letswifi/credential/certificatecredential.php
@@ -114,6 +114,6 @@ class CertificateCredential extends Credential
 
 	public function getAnonymousIdentity(): ?string
 	{
-		return null;
+		return substr($this->credentialId,3);
 	}
 }


### PR DESCRIPTION
Update certificatecredential.php to return AnonymousIdentity. If not set AnonymousIdentity gets not configured under Linux and Android.