### PR TITLE
fix: Fix filter_var syntax error in generateServerCertificate function

### DIFF
--- a/src/letswifi/realm/realm.php
+++ b/src/letswifi/realm/realm.php
@@ -101,7 +101,7 @@ class Realm
 	 */
 	public function generateServerCertificate( User $requester, string $commonName, DateTimeInterface $expiry ): PKCS12
 	{
-		if ( !\filter_var( $commonName, \FILTER_VALIDATE_DOMAIN | \FILTER_NULL_ON_FAILURE ) ) {
+		if ( !\filter_var( $commonName, \FILTER_VALIDATE_DOMAIN, \FILTER_NULL_ON_FAILURE ) ) {
 			throw new InvalidArgumentException( 'Common name for a server certificate must be a hostname' );
 		}
 		$serverKey = new PrivateKey( new OpenSSLConfig( OpenSSLConfig::KEY_EC ) );


### PR DESCRIPTION
See https://www.php.net/manual/en/function.filter-var.php for documentation on the `filter_var` function.

This change fixes an error in the `generateServerCertificate` function.

`FILTER_NULL_ON_FAILURE` is a flag, not a filter. This means it should be the third argument, not a part of the second argument.