### PR TITLE
new: Add pdo.sslca and pso.sslverify options for database connections.

### DIFF
--- a/src/letswifi/config.php
+++ b/src/letswifi/config.php
@@ -97,4 +97,17 @@ class Config
 
 		return $data;
 	}
+
+	public function getBoolOrNull( string $key ): ?bool
+	{
+		if ( !isset( $this->conf[$key] ) ) {
+			return null;
+		}
+		$data = $this->conf[$key];
+		if ( !\is_bool( $data ) ) {
+			throw new DomainException( "Expecting config key ${key} to be boolean, but is " . \gettype( $data ) );
+		}
+
+		return $data;
+	}
 }

--- a/src/letswifi/letswifiapp.php
+++ b/src/letswifi/letswifiapp.php
@@ -315,7 +315,7 @@ class LetsWifiApp
 			$username = $this->config->getStringOrNull( 'pdo.username' );
 			$password = $this->config->getStringOrNull( 'pdo.password' );
 
-			$this->pdo = new PDO( $dsn, $username, $password );
+			$this->pdo = new PDO( $dsn, $username, $password, $this->getPDOOptions() );
 			$this->pdo->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
 		}
 
@@ -339,5 +339,23 @@ class LetsWifiApp
 		}
 
 		return $realm;
+	}
+
+	private function getPDOOptions(): array
+	{
+		$options = [];
+
+		$ssl_ca_option = $this->config->getStringOrNull( 'pdo.sslca' );
+		$ssl_verify_option = $this->config->getBoolOrNull( 'pdo.sslverify' );
+
+		if ( null !== $ssl_ca_option ) {
+			$options[PDO::MYSQL_ATTR_SSL_CA] = $ssl_ca_option;
+		}
+
+		if ( null !== $ssl_verify_option ) {
+			$options[PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT] = $ssl_verify_option;
+		}
+
+		return $options;
 	}
 }


### PR DESCRIPTION
This change allows the project to connect to databases that require specific options.

The change also add a new helper function called `getBoolOrNull` in the same vein as `getStringOrNull` and similar functions, to make future boolean configurations easier to implement.