### PR TITLE
fix: Add null check in getSignerCa

### DIFF
--- a/src/letswifi/realm/realmmanager.php
+++ b/src/letswifi/realm/realmmanager.php
@@ -170,6 +170,9 @@ class RealmManager extends DatabaseStorage
 	public function getSignerCa( string $realm ): CA
 	{
 		$sub = $this->getSingleFieldFromTableWhere( 'realm_signer', 'signer_ca_sub', ['realm' => $realm] );
+		if (null === $sub) {
+			throw new DomainException( 'Signer CA not found' );
+		}
 		$ca = $this->getCA( $sub );
 		if ( null === $ca ) {
 			throw new DomainException( 'Signer CA not found' );


### PR DESCRIPTION
In the function `getSignerCa`, the result of a call to `getSingleFieldFromTableWhere` is not checked, unlike the result of `getCA`. This means that this function could pass an invalid argument to the `getCA`.