### PR TITLE
Add config option for EAP Outer Identity

### DIFF
--- a/config-dist/realms/example.com.conf.php
+++ b/config-dist/realms/example.com.conf.php
@@ -78,6 +78,12 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
+	// EAP username to present during authentication.  Needed if
+	// you wish to override the identity to be anonymous by
+	// eliminating the identifier before the "@".  Some systems
+	// use a generic string like "anonymous@realm.tld".
+	'eap_username' => '@example.com',
+
 	// Logo for the realm
 	// This will be displayed prominent in the apps
 	// If no logo is to be set, omit this whole entry

--- a/config-dist/realms/example.com.conf.php
+++ b/config-dist/realms/example.com.conf.php
@@ -78,11 +78,11 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
-	// EAP username to present during authentication.  Needed if
-	// you wish to override the identity to be anonymous by
-	// eliminating the identifier before the "@".  Some systems
-	// use a generic string like "anonymous@realm.tld".
-	'eap_username' => '@example.com',
+	// Optional outer identity to send for credentials in this
+	// realm.  Used if you wish to use an anonymous ID for all EAP
+	// requests rather than the CN of the certificate.  Common
+	// values include "@realm.tld" or "anonymous@realm.tld".
+	'outer_identity' => '@example.com',
 
 	// Logo for the realm
 	// This will be displayed prominent in the apps

--- a/config-dist/realms/staff.example.com.conf.php
+++ b/config-dist/realms/staff.example.com.conf.php
@@ -75,11 +75,11 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
-	// EAP username to present during authentication.  Needed if
-	// you wish to override the identity to be anonymous by
-	// eliminating the identifier before the "@".  Some systems
-	// use a generic string like "anonymous@realm.tld".
-	'eap_username' => '@staff.example.com',
+	// Optional outer identity to send for credentials in this
+	// realm.  Used if you wish to use an anonymous ID for all EAP
+	// requests rather than the CN of the certificate.  Common
+	// values include "@realm.tld" or "anonymous@realm.tld".
+	'outer_identity' => '@staff.example.com',
 
 	// Logo for the realm
 	// This will be displayed prominent in the apps

--- a/config-dist/realms/staff.example.com.conf.php
+++ b/config-dist/realms/staff.example.com.conf.php
@@ -75,6 +75,12 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
+	// EAP username to present during authentication.  Needed if
+	// you wish to override the identity to be anonymous by
+	// eliminating the identifier before the "@".  Some systems
+	// use a generic string like "anonymous@realm.tld".
+	'eap_username' => '@staff.example.com',
+
 	// Logo for the realm
 	// This will be displayed prominent in the apps
 	// If no logo is to be set, omit this whole entry

--- a/config-dist/realms/student.example.com.conf.php
+++ b/config-dist/realms/student.example.com.conf.php
@@ -75,6 +75,12 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
+	// EAP username to present during authentication.  Needed if
+	// you wish to override the identity to be anonymous by
+	// eliminating the identifier before the "@".  Some systems
+	// use a generic string like "anonymous@realm.tld".
+	'eap_username' => '@student.example.com',
+
 	// Logo for the realm
 	// This will be displayed prominent in the apps
 	// If no logo is to be set, omit this whole entry

--- a/config-dist/realms/student.example.com.conf.php
+++ b/config-dist/realms/student.example.com.conf.php
@@ -75,11 +75,11 @@ return [
 	// REQUIRED: Array, list of network IDs
 	'networks' => ['eduroam'],
 
-	// EAP username to present during authentication.  Needed if
-	// you wish to override the identity to be anonymous by
-	// eliminating the identifier before the "@".  Some systems
-	// use a generic string like "anonymous@realm.tld".
-	'eap_username' => '@student.example.com',
+	// Optional outer identity to send for credentials in this
+	// realm.  Used if you wish to use an anonymous ID for all EAP
+	// requests rather than the CN of the certificate.  Common
+	// values include "@realm.tld" or "anonymous@realm.tld".
+	'outer_identity' => '@student.example.com',
 
 	// Logo for the realm
 	// This will be displayed prominent in the apps

--- a/src/letswifi/credential/certificatecredential.php
+++ b/src/letswifi/credential/certificatecredential.php
@@ -110,9 +110,4 @@ class CertificateCredential extends Credential
 	{
 		return null !== $this->revoked;
 	}
-
-	public function getOuterIdentity(): ?string
-	{
-		return $this->credentialId;
-	}
 }

--- a/src/letswifi/credential/credential.php
+++ b/src/letswifi/credential/credential.php
@@ -63,6 +63,19 @@ abstract class Credential implements JsonSerializable
 
 	public function getOuterIdentity(): ?string
 	{
-		return \rawurlencode( $this->credentialId ?: 'anonymous' ) . "@{$this->realm->realmId}";
+		if ($this->realm->eapUsername) {
+			return $this->realm->eapUsername;
+		}
+		else if ($this->credentialId) {
+			if (str_contains($this->credentialId, '@')) {
+				return $this->credentialId;
+			}
+			else {
+				return \rawurlencode( $this->credentialId ) . "@{$this->realm->realmId}";
+			}
+		}
+		else {
+			return "anonymous@{$this->realm->realmId}";
+		}
 	}
 }

--- a/src/letswifi/credential/credential.php
+++ b/src/letswifi/credential/credential.php
@@ -63,19 +63,17 @@ abstract class Credential implements JsonSerializable
 
 	public function getOuterIdentity(): string
 	{
-		if ($this->realm->outerIdentity) {
+		if ( $this->realm->outerIdentity ) {
 			return $this->realm->outerIdentity;
 		}
-		else if ($this->credentialId) {
-			if (str_contains($this->credentialId, '@')) {
+		if ( $this->credentialId ) {
+			if ( \str_contains( $this->credentialId, '@' ) ) {
 				return $this->credentialId;
 			}
-			else {
-				return \rawurlencode( $this->credentialId ) . "@{$this->realm->realmId}";
-			}
+
+			return \rawurlencode( $this->credentialId ) . "@{$this->realm->realmId}";
 		}
-		else {
-			return "anonymous@{$this->realm->realmId}";
-		}
+
+		return "anonymous@{$this->realm->realmId}";
 	}
 }

--- a/src/letswifi/credential/credential.php
+++ b/src/letswifi/credential/credential.php
@@ -61,10 +61,10 @@ abstract class Credential implements JsonSerializable
 	/** @return T */
 	abstract public function getPayload();
 
-	public function getOuterIdentity(): ?string
+	public function getOuterIdentity(): string
 	{
-		if ($this->realm->eapUsername) {
-			return $this->realm->eapUsername;
+		if ($this->realm->outerIdentity) {
+			return $this->realm->outerIdentity;
 		}
 		else if ($this->credentialId) {
 			if (str_contains($this->credentialId, '@')) {

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -160,13 +160,10 @@ class AppleMobileconfigFormat extends Format
 					$result .= '					<string>' . $this::e( $serverName ) . '</string>'
 						. "\n";
 				}
-				$result .= '				</array>';
-				if ($this->credential->realm->eapUsername) {
-					$result .= "\n				<key>UserName</key>"
-					  . "\n				<value>"
-					  . $this::e( $this->credential->realm->eapUsername ) . "</value>";
-				}
-				$result .= "\n			</dict>"
+				$result .= '				</array>'
+				  . "\n				<key>UserName</key>"
+				  . "\n				<value>" . $this::e( $this->credential->getOuterIdentity ) . '</value>'
+				  . "\n			</dict>"
 					. "\n			<key>EncryptionType</key>"
 					. "\n			<string>WPA2</string>"
 					. "\n			<key>HIDDEN_NETWORK</key>"

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -162,7 +162,7 @@ class AppleMobileconfigFormat extends Format
 				}
 				$result .= '				</array>'
 				  . "\n				<key>UserName</key>"
-				  . "\n				<value>" . $this::e( $this->credential->getOuterIdentity() ) . '</value>'
+				  . "\n				<string>" . $this::e( $this->credential->getOuterIdentity() ) . '</string>'
 				  . "\n			</dict>"
 					. "\n			<key>EncryptionType</key>"
 					. "\n			<string>WPA2</string>"

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -160,8 +160,13 @@ class AppleMobileconfigFormat extends Format
 					$result .= '					<string>' . $this::e( $serverName ) . '</string>'
 						. "\n";
 				}
-				$result .= '				</array>'
-					. "\n			</dict>"
+				$result .= '				</array>';
+				if ($this->credential->realm->eapUsername) {
+					$result .= "\n				<key>UserName</key>"
+					  . "\n				<value>"
+					  . $this::e( $this->credential->realm->eapUsername ) . "</value>"
+				}
+				$result .= "\n			</dict>"
 					. "\n			<key>EncryptionType</key>"
 					. "\n			<string>WPA2</string>"
 					. "\n			<key>HIDDEN_NETWORK</key>"

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -164,7 +164,7 @@ class AppleMobileconfigFormat extends Format
 				if ($this->credential->realm->eapUsername) {
 					$result .= "\n				<key>UserName</key>"
 					  . "\n				<value>"
-					  . $this::e( $this->credential->realm->eapUsername ) . "</value>"
+					  . $this::e( $this->credential->realm->eapUsername ) . "</value>";
 				}
 				$result .= "\n			</dict>"
 					. "\n			<key>EncryptionType</key>"

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -162,7 +162,7 @@ class AppleMobileconfigFormat extends Format
 				}
 				$result .= '				</array>'
 				  . "\n				<key>UserName</key>"
-				  . "\n				<value>" . $this::e( $this->credential->getOuterIdentity ) . '</value>'
+				  . "\n				<value>" . $this::e( $this->credential->getOuterIdentity() ) . '</value>'
 				  . "\n			</dict>"
 					. "\n			<key>EncryptionType</key>"
 					. "\n			<string>WPA2</string>"

--- a/src/letswifi/format/eapconfigformat.php
+++ b/src/letswifi/format/eapconfigformat.php
@@ -180,15 +180,13 @@ class EapConfigFormat extends Format
 			. "\r\n\t\t\t\t</ServerSideCredential>";
 		$result .= ''
 			. "\r\n\t\t\t\t<ClientSideCredential>";
-		if ( null !== $identity ) {
-			// https://github.com/GEANT/CAT/blob/v2.0.3/devices/xml/eap-metadata.xsd
-			// The schema specifies <OuterIdentity>
-			// https://tools.ietf.org/html/draft-winter-opsawg-eap-metadata-02
-			// Expired draft specifices <AnonymousIdentity>
-			// cat.eduroam.org uses <OuterIdentity>, so we do too
-			$result .= ''
-				. "\r\n\t\t\t\t\t<OuterIdentity>" . $this->e( $identity ) . '</OuterIdentity>';
-		}
+		// https://github.com/GEANT/CAT/blob/v2.0.3/devices/xml/eap-metadata.xsd
+		// The schema specifies <OuterIdentity>
+		// https://tools.ietf.org/html/draft-winter-opsawg-eap-metadata-02
+		// Expired draft specifices <AnonymousIdentity>
+		// cat.eduroam.org uses <OuterIdentity>, so we do too
+		$result .= ''
+		  . "\r\n\t\t\t\t\t<OuterIdentity>" . $this->e( $identity ) . '</OuterIdentity>';
 		$result .= ''
 			. "\r\n\t\t\t\t\t" . '<ClientCertificate format="PKCS12" encoding="base64">' . \base64_encode( $pkcs12->getPKCS12Bytes( $this->passphrase ?: $defaultPassphrase ) ) . '</ClientCertificate>';
 		if ( !$this->passphrase ) {

--- a/src/letswifi/format/googleoncformat.php
+++ b/src/letswifi/format/googleoncformat.php
@@ -137,7 +137,7 @@ class GoogleOncFormat extends Format
 
 		$outerIdentity = $this->credential->getOuterIdentity();
 
-		$networkConfigurations = \array_filter( \array_map( fn ( Network $network ) => $this->generateNetworkConfiguration( $network, $clientCertID, $clientCertCN, $caIDs, $serverSubjectMatch, $outerIdentity ), $this->credential->realm->networks) );
+		$networkConfigurations = \array_filter( \array_map( fn ( Network $network ) => $this->generateNetworkConfiguration( $network, $clientCertID, $clientCertCN, $caIDs, $serverSubjectMatch, $outerIdentity ), $this->credential->realm->networks ) );
 
 		return [
 			'Type' => 'UnencryptedConfiguration',
@@ -152,7 +152,7 @@ class GoogleOncFormat extends Format
 	 * @param string        $clientCertCN       Common name of client certificate
 	 * @param array<string> $caIDs              IDs of server CA certificates
 	 * @param string        $serverSubjectMatch Substring certificate subject name must match
-	 * @param string	$outerIdentity      EAP outer identity username
+	 * @param string        $outerIdentity      EAP outer identity username
 	 *
 	 * @return ?array ONC NetworkConfiguration struct
 	 */

--- a/src/letswifi/format/googleoncformat.php
+++ b/src/letswifi/format/googleoncformat.php
@@ -135,7 +135,9 @@ class GoogleOncFormat extends Format
 
 		$clientCertCN = $pkcs12->x509->getSubject()->getCommonName();
 
-		$networkConfigurations = \array_filter( \array_map( fn ( Network $network ) => $this->generateNetworkConfiguration( $network, $clientCertID, $clientCertCN, $caIDs, $serverSubjectMatch ), $this->credential->realm->networks ) );
+		$outerIdentity = $this->credential->getOuterIdentity();
+
+		$networkConfigurations = \array_filter( \array_map( fn ( Network $network ) => $this->generateNetworkConfiguration( $network, $clientCertID, $clientCertCN, $caIDs, $serverSubjectMatch, $outerIdentity ), $this->credential->realm->networks) );
 
 		return [
 			'Type' => 'UnencryptedConfiguration',
@@ -150,10 +152,11 @@ class GoogleOncFormat extends Format
 	 * @param string        $clientCertCN       Common name of client certificate
 	 * @param array<string> $caIDs              IDs of server CA certificates
 	 * @param string        $serverSubjectMatch Substring certificate subject name must match
+	 * @param string	$outerIdentity      EAP outer identity username
 	 *
 	 * @return ?array ONC NetworkConfiguration struct
 	 */
-	protected function generateNetworkConfiguration( Network $network, string $clientCertID, string $clientCertCN, array $caIDs, string $serverSubjectMatch ): ?array
+	protected function generateNetworkConfiguration( Network $network, string $clientCertID, string $clientCertCN, array $caIDs, string $serverSubjectMatch, $outerIdentity ): ?array
 	{
 		if ( !$network instanceof NetworkSSID ) {
 			return null;
@@ -175,6 +178,7 @@ class GoogleOncFormat extends Format
 					'ClientCertRef' => $clientCertID,
 					'ClientCertType' => 'Ref',
 					'Identity' => $clientCertCN,
+					'AnonymousIdentity' => $outerIdentity,
 					'Outer' => 'EAP-TLS',
 					'SaveCredentials' => true,
 					'ServerCARefs' => \array_values( $caIDs ),

--- a/src/letswifi/profile/realm.php
+++ b/src/letswifi/profile/realm.php
@@ -39,7 +39,7 @@ class Realm implements JsonSerializable
 		public readonly ?Logo $logo = null,
 		public readonly ?string $contactId = null,
 		public readonly array $admins = [],
-		public readonly ?string $eapUsername = null,
+		public readonly ?string $outerIdentity = null,
 	) {
 	}
 
@@ -62,7 +62,7 @@ class Realm implements JsonSerializable
 			description: $realmData->getMultiLanguageStringOrNull( 'description' ),
 			contactId: $realmData->getStringOrNull( 'contact' ),
 			admins: $realmData->has( 'admins' ) ? $realmData->getStringArray( 'admins' ) : [],
-			eapUsername: $realmData->getStringOrNull('eap_username'),
+			outerIdentity: $realmData->getStringOrNull('outer_identity'),
 		);
 	}
 
@@ -80,7 +80,7 @@ class Realm implements JsonSerializable
 	}
 
 	/**
-	 * @return array{realm_id:string,display_name:MultiLanguageString,description:?MultiLanguageString,contact:?Contact,location:array<Location>,eap_username:?string,logo:bool,signer:string,trust:array<string>,networks:array<string,array{oids?:array<string>,nai_realms?:array<string>,ssid?:string,display_name:MultiLanguageString}>}
+	 * @return array{realm_id:string,display_name:MultiLanguageString,description:?MultiLanguageString,contact:?Contact,location:array<Location>,outer_identity:?string,logo:bool,signer:string,trust:array<string>,networks:array<string,array{oids?:array<string>,nai_realms?:array<string>,ssid?:string,display_name:MultiLanguageString}>}
 	 */
 	public function jsonSerialize(): array
 	{
@@ -89,7 +89,7 @@ class Realm implements JsonSerializable
 			'display_name' => $this->displayName,
 			'description' => $this->description,
 			'contact' => $this->getContact(),
-			'eap_username' => $this->eapUsername,
+			'outer_identity' => $this->outerIdentity,
 			'location' => $this->location,
 			'logo' => isset( $this->logo ),
 			'signer' => $this->signer,

--- a/src/letswifi/profile/realm.php
+++ b/src/letswifi/profile/realm.php
@@ -62,7 +62,7 @@ class Realm implements JsonSerializable
 			description: $realmData->getMultiLanguageStringOrNull( 'description' ),
 			contactId: $realmData->getStringOrNull( 'contact' ),
 			admins: $realmData->has( 'admins' ) ? $realmData->getStringArray( 'admins' ) : [],
-			outerIdentity: $realmData->getStringOrNull('outer_identity'),
+			outerIdentity: $realmData->getStringOrNull( 'outer_identity' ),
 		);
 	}
 

--- a/src/letswifi/profile/realm.php
+++ b/src/letswifi/profile/realm.php
@@ -39,6 +39,7 @@ class Realm implements JsonSerializable
 		public readonly ?Logo $logo = null,
 		public readonly ?string $contactId = null,
 		public readonly array $admins = [],
+		public readonly ?string $eapUsername = null,
 	) {
 	}
 
@@ -61,6 +62,7 @@ class Realm implements JsonSerializable
 			description: $realmData->getMultiLanguageStringOrNull( 'description' ),
 			contactId: $realmData->getStringOrNull( 'contact' ),
 			admins: $realmData->has( 'admins' ) ? $realmData->getStringArray( 'admins' ) : [],
+			eapUsername: $realmData->getStringOrNull('eap_username'),
 		);
 	}
 
@@ -78,7 +80,7 @@ class Realm implements JsonSerializable
 	}
 
 	/**
-	 * @return array{realm_id:string,display_name:MultiLanguageString,description:?MultiLanguageString,contact:?Contact,location:array<Location>,logo:bool,signer:string,trust:array<string>,networks:array<string,array{oids?:array<string>,nai_realms?:array<string>,ssid?:string,display_name:MultiLanguageString}>}
+	 * @return array{realm_id:string,display_name:MultiLanguageString,description:?MultiLanguageString,contact:?Contact,location:array<Location>,eap_username:?string,logo:bool,signer:string,trust:array<string>,networks:array<string,array{oids?:array<string>,nai_realms?:array<string>,ssid?:string,display_name:MultiLanguageString}>}
 	 */
 	public function jsonSerialize(): array
 	{
@@ -87,6 +89,7 @@ class Realm implements JsonSerializable
 			'display_name' => $this->displayName,
 			'description' => $this->description,
 			'contact' => $this->getContact(),
+			'eap_username' => $this->eapUsername,
 			'location' => $this->location,
 			'logo' => isset( $this->logo ),
 			'signer' => $this->signer,


### PR DESCRIPTION
We wanted to be able to specify an anonymous outer identity on our configured clients.  There were some hints of this in the existing eap config and credential code, so we built on that.

Added a realm option "outer_identity" to be able to specify an anonymous outer identity that overrides the cert CN.

Added "outer_identity" config variable and comments to sample realm config files.

Refactored Credential getOuterIdentity() to override with this value when present, otherwise return an identity derived from the cert or "anonymous" (which was already present).  Changed to not be nullable as a value is always returned.

Added output to Google and Apple config generation that establishes the outer identity, making a call to the function above.  Since it always returns a value, we unconditionally emit this config value.

Tested on macOS.  I don't have an Android client handy, so Google config was inspected manually for correctness but not tested.  It's only a single attribute so hoping this is straightforward.