### PR TITLE
Include entire client chain in PKCS12

### DIFF
--- a/src/letswifi/credential/certificatecredentialissuer.php
+++ b/src/letswifi/credential/certificatecredentialissuer.php
@@ -155,7 +155,7 @@ class CertificateCredentialIssuer implements CredentialIssuer
 		$userCert = $csr->sign( $caCert, $caKey, $expiry, $conf, $serial );
 		$this->logCompletedUserCredential( $userCert, 'client' );
 
-		return new PKCS12( $userCert, $userKey, [$caCert] );
+		return new PKCS12( $userCert, $userKey, $this->realm->getSignerChain() );
 	}
 
 	/**

--- a/src/letswifi/format/applemobileconfigformat.php
+++ b/src/letswifi/format/applemobileconfigformat.php
@@ -34,9 +34,10 @@ class AppleMobileconfigFormat extends Format
 
 		$caCertificates = $this->credential->realm->getTrustedCACertificates();
 
-		// If we include the CA, MacOS will also trust that CA for HTTPS traffic
+		// MacOS won't use the client cert unless there is a full
+		// chain of trust, so include the CA
 		// MacOS needs the bundle to be 3DES encoded
-		$pkcs12 = $this->credential->getPKCS12( ca: false, des: true );
+		$pkcs12 = $this->credential->getPKCS12( ca: true, des: true );
 
 		$result = '<?xml version="1.0" encoding="UTF-8"?>'
 			. "\n" . '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'

--- a/src/letswifi/profile/realm.php
+++ b/src/letswifi/profile/realm.php
@@ -89,6 +89,16 @@ class Realm implements JsonSerializable
 	}
 
 	/**
+	 * Return the complete trust chain for the CA that signs the user certs
+	 *
+	 * @return array<X509>
+	 */
+	public function getSignerChain(): array
+	{
+		return $this->profileService->getCertificatesWithChain( $this->signer );
+	}
+
+	/**
 	 * @return array{realm_id:string,display_name:MultiLanguageString,description:?MultiLanguageString,contact:?Contact,location:array<Location>,logo:bool,signer:string,trust:array<string>,networks:array<string,array{oids?:array<string>,nai_realms?:array<string>,ssid?:string,display_name:MultiLanguageString}>}
 	 */
 	public function jsonSerialize(): array


### PR DESCRIPTION
#76 

In 2.0.0-beta4 we discovered that Apple mobilconfigs didn't include the complete client trust chain, and this prevented the certificate in the config from being used.

We found that the applemobileconfig code was using "ca: false" when emitting the PKCS12 bytes, causing only the cert to be added to the payload.  Changed that to "true" to include the entire chain.

Additionally, the CertificateCredentialIssuer was only including the signing CA in the PKCS12, instead of the complete chain.  In the default setup this assumption holds (there is no intermediate), but for completeness we added a method that generates the full client signing chain, and uses that in the PKCS12 construction.

We generated a test CA with an intermediate, imported, and issued a cert through letswifi (without the signing certs being listed in the trust anchors for the realm).  Confirmed that macos was able to correctly authenticate where before it could not.

Removed the comment about SSL trust on the signing cert chain; Keychain access for us shows that the signing chain is trusted for all uses *except* SSL (which is left as "no value specified".